### PR TITLE
Fix grammar in Rich King achievements descriptions

### DIFF
--- a/Renewal/System/achievement_list_EN.lub
+++ b/Renewal/System/achievement_list_EN.lub
@@ -4844,7 +4844,7 @@ achievement_tbl = {
 		title = "Rich King (1)",
 		content = {
 			summary = "Hold more than 10,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 10,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 10,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 10,000 zeny in pocket" } },
 		reward = {},
@@ -4858,7 +4858,7 @@ achievement_tbl = {
 		title = "Rich King (2)",
 		content = {
 			summary = "Hold more than 100,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 100,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 100,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 100,000 zeny in pocket" } },
 		reward = {},
@@ -4872,7 +4872,7 @@ achievement_tbl = {
 		title = "Rich King (3)",
 		content = {
 			summary = "Hold more than 1,000,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 1,000,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 1,000,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 1,000,000 zeny in pocket" } },
 		reward = {},
@@ -4886,7 +4886,7 @@ achievement_tbl = {
 		title = "Rich King (4)",
 		content = {
 			summary = "Hold more than 10,000,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 10,000,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 10,000,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 10,000,000 zeny in pocket" } },
 		reward = {},
@@ -4900,7 +4900,7 @@ achievement_tbl = {
 		title = "Rich King (5)",
 		content = {
 			summary = "Hold more than 100,000,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 100,000,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 100,000,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 100,000,000 zeny in pocket" } },
 		reward = {},
@@ -4914,7 +4914,7 @@ achievement_tbl = {
 		title = "Rich King (6)",
 		content = {
 			summary = "Hold more than 1,000,000,000 zeny in pocket",
-			details = "Money is not everything, that because you're poor. Hold more than 1,000,000,000 zeny in pocket."
+			details = "Money is not everything? That is because you are poor. Hold more than 1,000,000,000 zeny in pocket."
 		},
 		resource = { [1] = { text = "Hold more than 1,000,000,000 zeny in pocket" } },
 		reward = {},


### PR DESCRIPTION
This PR fixes: "that because" -> "that is because"
First sentence has "is not" so I kept the same "non-abbreviated" style for the second sentence.