### PR TITLE
Some changes to CLSGenerator.bat

### DIFF
--- a/Tools/CLSGenerator.bat
+++ b/Tools/CLSGenerator.bat
@@ -60,8 +60,7 @@ if %type% equ 1 (
     xcopy "%sourceDataPath%\cls\lapineddukddakbox.lub" "%destinationDataPath%\cls\lapineddukddakbox.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\lapineupgradebox.lub" "%destinationDataPath%\cls\lapineupgradebox.lub"* /E /H /C /I /Y
 ) else if %type% equ 7 (
-    xcopy "%sourceDataPath%\navigation\navi_f_krpri.lub" "%destinationDataPath%\navigation\navi_f_krpri.lub"* /E /H /C /I /Y
-    xcopy "%sourceDataPath%\navigation\navi_f_krsak.lub" "%destinationDataPath%\navigation\navi_f_krsak.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\navigation\" "%destinationDataPath%\navigation\"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_link.lub" "%destinationDataPath%\cls\navi_link.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_linkdistance.lub" "%destinationDataPath%\cls\navi_linkdistance.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_map.lub" "%destinationDataPath%\cls\navi_map.lub"* /E /H /C /I /Y
@@ -72,8 +71,7 @@ if %type% equ 1 (
     xcopy "%sourceDataPath%\cls\navi_scroll.lub" "%destinationDataPath%\cls\navi_scroll.lub"* /E /H /C /I /Y
 ) else if %type% equ 8 (
     xcopy "%sourceDataPath%\cls\questinfo_f.lub" "%destinationDataPath%\cls\questinfo_f.lub"* /E /H /C /I /Y
-    xcopy "%sourceSystemPath%\OngoingQuests_CLS.lub" "%destinationSystemPath%\OngoingQuests_CLS.lub"* /E /H /C /I /Y
-    xcopy "%sourceSystemPath%\RecommendedQuests_CLS.lub" "%destinationSystemPath%\RecommendedQuests_CLS.lub"* /E /H /C /I /Y
+    xcopy "%sourceSystemPath%\" "%destinationSystemPath%\"* /E /H /C /I /Y
 ) else if %type% equ 9 (
     xcopy "%sourceDataPath%\cls\signboardlist.lub" "%destinationDataPath%\cls\signboardlist.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\signboardlist_f.lub" "%destinationDataPath%\cls\signboardlist_f.lub"* /E /H /C /I /Y

--- a/Tools/CLSGenerator.bat
+++ b/Tools/CLSGenerator.bat
@@ -5,112 +5,106 @@ echo This will help you to copy over the files you want and need based on the ch
 echo It will loop itself until you close the program or choose Exit.
 echo =================================================================
 pause
-if exist "Client\data\luafiles514\lua files\cls" rmdir /Q /S "Client\data\luafiles514\lua files\cls\"
+
+set "sourceDataPath=..\Addons\Custom Lua Support\data\luafiles514\lua files"
+set "sourceSystemPath=..\Addons\Custom Lua Support\System"
+set "destinationDataPath=.\Client\data"
+set "destinationSystemPath=.\Client\System"
+
 :CLSMenu
 cls
 echo ===============
-echo [1] All In One Package %cls[0]%
-echo [2] Headgears %cls[1]%
-echo [3] Random Options %cls[2]%
-echo [4] HatEffects %cls[3]%
-echo [5] NPC/Mob and Pets %cls[4]%
-echo [6] Lapine Boxes %cls[5]%
-echo [7] Navigation %cls[6]%
-echo [8] Quests %cls[7]%
-echo [9] Signboards %cls[8]%
-echo [10] Robes/Costume Garments %cls[9]%
-echo [11] Titles %cls[10]%
-echo [12] Weapons %cls[11]%
-echo [13] World Map %cls[12]%
+echo [1] All In One Package %cls[1]%
+echo [2] Headgears %cls[2]%
+echo [3] Random Options %cls[3]%
+echo [4] HatEffects %cls[4]%
+echo [5] NPC/Mob and Pets %cls[5]%
+echo [6] Lapine Boxes %cls[6]%
+echo [7] Navigation %cls[7]%
+echo [8] Quests %cls[8]%
+echo [9] Signboards %cls[9]%
+echo [10] Robes/Costume Garments %cls[10]%
+echo [11] Titles %cls[11]%
+echo [12] Weapons %cls[12]%
+echo [13] World Map %cls[13]%
 echo [14] Exit
 echo ===============
-set /p type="Now choose:"
-if %type%==1 (
-	xcopy "..\Addons\Custom Lua Support\" ".\Client\" /E /H /C /I /Y
-	set cls[0]=Copied
+set /p type="Now choose: "
+
+if %type% lss 14 (
+    if exist "Client\data\luafiles514\lua files\cls" rmdir /Q /S "Client\data\luafiles514\lua files\cls\"
 )
-if %type%==2 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\accessoryid.lub" ".\Client\data\luafiles514\lua files\cls\accessoryid.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\accname.lub" ".\Client\data\luafiles514\lua files\cls\accname.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\accname_f.lub" ".\Client\data\luafiles514\lua files\cls\accname_f.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\datainfo\TB_Layer_Priority.lub" ".\Client\data\luafiles514\lua files\datainfo\TB_Layer_Priority.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\tb_layer_priority.lub" ".\Client\data\luafiles514\lua files\cls\tb_layer_priority.lub"* /E /H /C /I /Y
-	set cls[1]=Copied
+
+if %type% equ 1 (
+    xcopy "..\Addons\Custom Lua Support\" ".\Client\" /E /H /C /I /Y
+) else if %type% equ 2 (
+    xcopy "%sourceDataPath%\cls\accessoryid.lub" "%destinationDataPath%\cls\accessoryid.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\accname.lub" "%destinationDataPath%\cls\accname.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\accname_f.lub" "%destinationDataPath%\cls\accname_f.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\datainfo\TB_Layer_Priority.lub" "%destinationDataPath%\datainfo\TB_Layer_Priority.lub"* /E /H /C /I /Y
+) else if %type% equ 3 (
+    xcopy "%sourceDataPath%\cls\enumvar.lub" "%destinationDataPath%\cls\enumvar.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\randomoption.lub" "%destinationDataPath%\cls\randomoption.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\addrandomoption_f.lub" "%destinationDataPath%\cls\addrandomoption_f.lub"* /E /H /C /I /Y
+) else if %type% equ 4 (
+    xcopy "%sourceDataPath%\hateffectinfo\hateffectinfo.lub" "%destinationDataPath%\hateffectinfo\hateffectinfo.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\hateffectinfo.lub" "%destinationDataPath%\cls\hateffectinfo.lub"* /E /H /C /I /Y
+) else if %type% equ 5 (
+    xcopy "%sourceDataPath%\cls\jobname.lub" "%destinationDataPath%\cls\jobname.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\jobname_f.lub" "%destinationDataPath%\cls\jobname_f.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\npcidentity.lub" "%destinationDataPath%\cls\npcidentity.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\petinfo.lub" "%destinationDataPath%\cls\petinfo.lub"* /E /H /C /I /Y
+) else if %type% equ 6 (
+    xcopy "%sourceDataPath%\datainfo\lapineddukddakbox.lub" "%destinationDataPath%\datainfo\lapineddukddakbox.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\datainfo\LapineUpgradeBox.lub" "%destinationDataPath%\datainfo\LapineUpgradeBox.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\lapineddukddakbox.lub" "%destinationDataPath%\cls\lapineddukddakbox.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\lapineupgradebox.lub" "%destinationDataPath%\cls\lapineupgradebox.lub"* /E /H /C /I /Y
+) else if %type% equ 7 (
+    xcopy "%sourceDataPath%\navigation\navi_f_krpri.lub" "%destinationDataPath%\navigation\navi_f_krpri.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\navigation\navi_f_krsak.lub" "%destinationDataPath%\navigation\navi_f_krsak.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_link.lub" "%destinationDataPath%\cls\navi_link.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_linkdistance.lub" "%destinationDataPath%\cls\navi_linkdistance.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_map.lub" "%destinationDataPath%\cls\navi_map.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_mob.lub" "%destinationDataPath%\cls\navi_mob.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_npc.lub" "%destinationDataPath%\cls\navi_npc.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_npcdistance.lub" "%destinationDataPath%\cls\navi_npcdistance.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_picknpc.lub" "%destinationDataPath%\cls\navi_picknpc.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\navi_scroll.lub" "%destinationDataPath%\cls\navi_scroll.lub"* /E /H /C /I /Y
+) else if %type% equ 8 (
+    xcopy "%sourceDataPath%\cls\questinfo_f.lub" "%destinationDataPath%\cls\questinfo_f.lub"* /E /H /C /I /Y
+    xcopy "%sourceSystemPath%\OngoingQuests_CLS.lub" "%destinationSystemPath%\OngoingQuests_CLS.lub"* /E /H /C /I /Y
+    xcopy "%sourceSystemPath%\RecommendedQuests_CLS.lub" "%destinationSystemPath%\RecommendedQuests_CLS.lub"* /E /H /C /I /Y
+) else if %type% equ 9 (
+    xcopy "%sourceDataPath%\cls\signboardlist.lub" "%destinationDataPath%\cls\signboardlist.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\signboardlist_f.lub" "%destinationDataPath%\cls\signboardlist_f.lub"* /E /H /C /I /Y
+) else if %type% equ 10 (
+    xcopy "%sourceDataPath%\cls\spriterobeid.lub" "%destinationDataPath%\cls\spriterobeid.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\spriterobename.lub" "%destinationDataPath%\cls\spriterobename.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\spriterobename_f.lub" "%destinationDataPath%\cls\spriterobename_f.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\transparentitem.lub" "%destinationDataPath%\cls\transparentitem.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\transparentitem_f.lub" "%destinationDataPath%\cls\transparentitem_f.lub"* /E /H /C /I /Y
+) else if %type% equ 11 (
+    xcopy "%sourceDataPath%\datainfo\titletable.lub" "%destinationDataPath%\datainfo\titletable.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\titletable.lub" "%destinationDataPath%\cls\titletable.lub"* /E /H /C /I /Y
+) else if %type% equ 12 (
+    xcopy "%sourceDataPath%\cls\weapontable.lub" "%destinationDataPath%\cls\weapontable.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\weapontable_f.lub" "%destinationDataPath%\cls\weapontable_f.lub"* /E /H /C /I /Y
+) else if %type% equ 13 (
+    xcopy "%sourceDataPath%\cls\worldviewdata_f.lub" "%destinationDataPath%\cls\worldviewdata_f.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\worldviewdata_language.lub" "%destinationDataPath%\cls\worldviewdata_language.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\worldviewdata_list.lub" "%destinationDataPath%\cls\worldviewdata_list.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\cls\worldviewdata_table.lub" "%destinationDataPath%\cls\worldviewdata_table.lub"* /E /H /C /I /Y
 )
-if %type%==3 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\enumvar.lub" ".\Client\data\luafiles514\lua files\cls\enumvar.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\randomoption.lub" ".\Client\data\luafiles514\lua files\cls\randomoption.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\addrandomoption_f.lub" ".\Client\data\luafiles514\lua files\cls\addrandomoption_f.lub"* /E /H /C /I /Y
-	set cls[2]=Copied
+
+if %type% lss 14 (
+    set cls[%type%]= [ Copied ]
+
+    if %type% equ 1 (
+        for /L %%i in (2,1,13) do (
+            set cls[%%i]= [ Copied ]
+        )
+    )
+
+    pause
+    goto CLSMenu
 )
-if %type%==4 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\hateffectinfo\hateffectinfo.lub" ".\Client\data\luafiles514\lua files\hateffectinfo\hateffectinfo.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\hateffectinfo.lub" ".\Client\data\luafiles514\lua files\cls\hateffectinfo.lub"* /E /H /C /I /Y
-	set cls[3]=Copied
-)
-if %type%==5 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\jobname.lub" ".\Client\data\luafiles514\lua files\cls\jobname.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\jobname_f.lub" ".\Client\data\luafiles514\lua files\cls\jobname_f.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\npcidentity.lub" ".\Client\data\luafiles514\lua files\cls\npcidentity.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\petinfo.lub" ".\Client\data\luafiles514\lua files\cls\petinfo.lub"* /E /H /C /I /Y
-	set cls[4]=Copied
-)
-if %type%==6 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\datainfo\lapineddukddakbox.lub" ".\Client\data\luafiles514\lua files\datainfo\lapineddukddakbox.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\datainfo\LapineUpgradeBox.lub" ".\Client\data\luafiles514\lua files\datainfo\LapineUpgradeBox.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\lapineddukddakbox.lub" ".\Client\data\luafiles514\lua files\cls\lapineddukddakbox.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\lapineupgradebox.lub" ".\Client\data\luafiles514\lua files\cls\lapineupgradebox.lub"* /E /H /C /I /Y
-	set cls[5]=Copied
-)
-if %type%==7 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\navigation\navi_f_krpri.lub" ".\Client\data\luafiles514\lua files\navigation\navi_f_krpri.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\navigation\navi_f_krsak.lub" ".\Client\data\luafiles514\lua files\navigation\navi_f_krsak.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_link.lub" ".\Client\data\luafiles514\lua files\cls\navi_link.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_linkdistance.lub" ".\Client\data\luafiles514\lua files\cls\navi_linkdistance.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_map.lub" ".\Client\data\luafiles514\lua files\cls\navi_map.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_mob.lub" ".\Client\data\luafiles514\lua files\cls\navi_mob.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_npc.lub" ".\Client\data\luafiles514\lua files\cls\navi_npc.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_npcdistance.lub" ".\Client\data\luafiles514\lua files\cls\navi_npcdistance.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_picknpc.lub" ".\Client\data\luafiles514\lua files\cls\navi_picknpc.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\navi_scroll.lub" ".\Client\data\luafiles514\lua files\cls\navi_scroll.lub"* /E /H /C /I /Y
-	set cls[6]=Copied
-)
-if %type%==8 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\questinfo_f.lub" ".\Client\data\luafiles514\lua files\cls\questinfo_f.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\System\OngoingQuests_CLS.lub" ".\Client\System\OngoingQuests_CLS.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\System\RecommendedQuests_CLS.lub" ".\Client\System\RecommendedQuests_CLS.lub"* /E /H /C /I /Y
-	set cls[7]=Copied
-)
-if %type%==9 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\signboardlist.lub" ".\Client\data\luafiles514\lua files\cls\signboardlist.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\signboardlist_f.lub" ".\Client\data\luafiles514\lua files\cls\signboardlist_f.lub"* /E /H /C /I /Y
-	set cls[8]=Copied
-)
-if %type%==10 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\spriterobeid.lub" ".\Client\data\luafiles514\lua files\cls\spriterobeid.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\spriterobename.lub" ".\Client\data\luafiles514\lua files\cls\spriterobename.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\spriterobename_f.lub" ".\Client\data\luafiles514\lua files\cls\spriterobename_f.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\transparentitem.lub" ".\Client\data\luafiles514\lua files\cls\transparentitem.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\transparentitem_f.lub" ".\Client\data\luafiles514\lua files\cls\transparentitem_f.lub"* /E /H /C /I /Y
-	set cls[9]=Copied
-)
-if %type%==11 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\datainfo\titletable.lub" ".\Client\data\luafiles514\lua files\datainfo\titletable.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\titletable.lub" ".\Client\data\luafiles514\lua files\cls\titletable.lub"* /E /H /C /I /Y
-	set cls[10]=Copied
-)
-if %type%==12 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\weapontable.lub" ".\Client\data\luafiles514\lua files\cls\weapontable.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\weapontable_f.lub" ".\Client\data\luafiles514\lua files\cls\weapontable_f.lub"* /E /H /C /I /Y
-	set cls[11]=Copied
-)
-if %type%==13 (
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\worldviewdata_f.lub" ".\Client\data\luafiles514\lua files\cls\worldviewdata_f.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\worldviewdata_language.lub" ".\Client\data\luafiles514\lua files\cls\worldviewdata_language.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\worldviewdata_list.lub" ".\Client\data\luafiles514\lua files\cls\worldviewdata_list.lub"* /E /H /C /I /Y
-	xcopy "..\Addons\Custom Lua Support\data\luafiles514\lua files\cls\worldviewdata_table.lub" ".\Client\data\luafiles514\lua files\cls\worldviewdata_table.lub"* /E /H /C /I /Y
-	set cls[12]=Copied
-)
-if %type%==14 exit
-pause
-goto CLSMenu

--- a/Tools/CLSGenerator.bat
+++ b/Tools/CLSGenerator.bat
@@ -103,14 +103,15 @@ if %type% equ 1 (
 )
 
 if %type% lss 14 (
-    set cls[%type%]= [ Copied ]
-
+    
     if %type% equ 1 (
         for /L %%i in (2,1,13) do (
             set cls[%%i]= [ Copied ]
         )
-    )
-
+    ) else (
+		set cls[%type%]= [ Copied ]
+	)
+	
     pause
     goto CLSMenu
 )

--- a/Tools/CLSGenerator.bat
+++ b/Tools/CLSGenerator.bat
@@ -1,7 +1,13 @@
 @echo off
 echo =================================================================
 echo Welcome to the Custom Lua Support Generator!
-echo This will help you to copy over the files you want and need based on the choice you make.
+echo.
+echo The Custom Lua Support (or CLS) was created to assist you further
+echo in adding your custom entries to seperate files, split from the
+echo original files, so it's easier to update the translation files.
+echo.
+echo This will help you to copy over the files you want and need based 
+echo on the choice you make.
 echo It will loop itself until you close the program or choose Exit.
 echo =================================================================
 pause
@@ -60,7 +66,8 @@ if %type% equ 1 (
     xcopy "%sourceDataPath%\cls\lapineddukddakbox.lub" "%destinationDataPath%\cls\lapineddukddakbox.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\lapineupgradebox.lub" "%destinationDataPath%\cls\lapineupgradebox.lub"* /E /H /C /I /Y
 ) else if %type% equ 7 (
-    xcopy "%sourceDataPath%\navigation\" "%destinationDataPath%\navigation\"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\navigation\navi_f_krpri.lub" "%destinationDataPath%\navigation\navi_f_krpri.lub"* /E /H /C /I /Y
+    xcopy "%sourceDataPath%\navigation\navi_f_krsak.lub" "%destinationDataPath%\navigation\navi_f_krsak.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_link.lub" "%destinationDataPath%\cls\navi_link.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_linkdistance.lub" "%destinationDataPath%\cls\navi_linkdistance.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\navi_map.lub" "%destinationDataPath%\cls\navi_map.lub"* /E /H /C /I /Y
@@ -71,7 +78,8 @@ if %type% equ 1 (
     xcopy "%sourceDataPath%\cls\navi_scroll.lub" "%destinationDataPath%\cls\navi_scroll.lub"* /E /H /C /I /Y
 ) else if %type% equ 8 (
     xcopy "%sourceDataPath%\cls\questinfo_f.lub" "%destinationDataPath%\cls\questinfo_f.lub"* /E /H /C /I /Y
-    xcopy "%sourceSystemPath%\" "%destinationSystemPath%\"* /E /H /C /I /Y
+    xcopy "%sourceSystemPath%\OngoingQuests_CLS.lub" "%destinationSystemPath%\OngoingQuests_CLS.lub"* /E /H /C /I /Y
+    xcopy "%sourceSystemPath%\RecommendedQuests_CLS.lub" "%destinationSystemPath%\RecommendedQuests_CLS.lub"* /E /H /C /I /Y
 ) else if %type% equ 9 (
     xcopy "%sourceDataPath%\cls\signboardlist.lub" "%destinationDataPath%\cls\signboardlist.lub"* /E /H /C /I /Y
     xcopy "%sourceDataPath%\cls\signboardlist_f.lub" "%destinationDataPath%\cls\signboardlist_f.lub"* /E /H /C /I /Y


### PR DESCRIPTION
⁕ Changed %cls[x] values to mach menu number options 
⁕ Now it deletes the folder cls after you have selected an option 
⁕ Now after you choose "All in One Package", all the other options will show "[ Copied ]" too
⁕ Added Variables to store common path
⁕ When the user chooses option 7 & 8, script copies whole folder instead of individual files ( navi and system files, both isolated )
⁕ Added brief explanation of what CLS is at the beginning of the script