### PR TITLE
Use the international word 'Kafra' instead of 'Kapra' in Renewal tipoftheday

### DIFF
--- a/Translation/Renewal/tipoftheday.txt
+++ b/Translation/Renewal/tipoftheday.txt
@@ -129,7 +129,7 @@ Description of some abnormal status
 #
 Experience values will be deducted at death. After using skills or a battle, a 5-second delay is forced before you may go offline
 #
-Query the Kapra staff for access to storage, save points and leasing pushcarts.
+Query the Kafra staff for access to storage, save points and leasing pushcarts.
 #
 [Alt] + [J] : Can use to see the adopt pet's
 #


### PR DESCRIPTION
As we all know, 'Kafra' is the international word for these fine ladies. I only found one occurence of the Korean version 'Kapra' so let's fix it. 