### PR TITLE
Ignore folder generated inside tools/client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Tools/Client/


### PR DESCRIPTION
This PR creates a .gitignore file to ignore the automatically generated folders inside the Tools/Client directory.

This change ensures that Git will ignore any generated folders within the Tools/Client directory.