### PR TITLE
Fix: Location names and cardinal directions in Achievements

### DIFF
--- a/Translation/Renewal/System/achievement_list_EN.lub
+++ b/Translation/Renewal/System/achievement_list_EN.lub
@@ -1113,9 +1113,9 @@ achievement_tbl = {
 		title = "Lighthalzen Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in lighthalzen field"
+			details = "Discover treasure in Lighthalzen field"
 		},
-		resource = { [1] = { text = "Discover treasure in lighthalzen field" } },
+		resource = { [1] = { text = "Discover treasure in Lighthalzen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},

--- a/Translation/Renewal/System/achievement_list_EN.lub
+++ b/Translation/Renewal/System/achievement_list_EN.lub
@@ -4005,7 +4005,7 @@ achievement_tbl = {
 		title = "Poring is Love",
 		content = {
 			summary = "Complete all objective tasks",
-			details = "You're the true enthusiast of poring things!"
+			details = "You're the true enthusiast of Poring things!"
 		},
 		resource = {
 			[1] = { text = "Complete 'Poring - taming' challenge", shortcut = 230101 },

--- a/Translation/Renewal/System/achievement_list_EN.lub
+++ b/Translation/Renewal/System/achievement_list_EN.lub
@@ -1309,9 +1309,9 @@ achievement_tbl = {
 		title = "North Bitfrost Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in North Bifrost field"
+			details = "Discover treasure in north Bifrost field"
 		},
-		resource = { [1] = { text = "Discover treasure in North Bifrost field" } },
+		resource = { [1] = { text = "Discover treasure in north Bifrost field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1323,9 +1323,9 @@ achievement_tbl = {
 		title = "South Bitfrost Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in South Bifrost field"
+			details = "Discover treasure in south Bifrost field"
 		},
-		resource = { [1] = { text = "Discover treasure in South Bifrost field" } },
+		resource = { [1] = { text = "Discover treasure in south Bifrost field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -3097,7 +3097,7 @@ achievement_tbl = {
 		title = "North Mjolnir Explorer",
 		content = {
 			summary = "Complete field exploration objectives",
-			details = "Complete exploring surrounding North Mjolnir"
+			details = "Complete exploring surrounding north Mjolnir"
 		},
 		resource = {
 			[1] = { text = "North Mjolnir Field Exploration(1) completed", shortcut = 120032 },
@@ -3117,7 +3117,7 @@ achievement_tbl = {
 		title = "South Mjolnir Explorer",
 		content = {
 			summary = "Complete field exploration objectives",
-			details = "Complete exploring surrounding South Mjolnir"
+			details = "Complete exploring surrounding south Mjolnir"
 		},
 		resource = {
 			[1] = { text = "South Mjolnir Field Exploration(1) completed", shortcut = 120037 },

--- a/Translation/Renewal/System/achievement_list_EN.lub
+++ b/Translation/Renewal/System/achievement_list_EN.lub
@@ -49,9 +49,9 @@ achievement_tbl = {
 		title = "North Prontera Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north prontera field"
+			details = "Discover treasure in north Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in north prontera field" } },
+		resource = { [1] = { text = "Discover treasure in north Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -63,9 +63,9 @@ achievement_tbl = {
 		title = "North Prontera Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north prontera field"
+			details = "Discover treasure in north Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in north prontera field" } },
+		resource = { [1] = { text = "Discover treasure in north Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -77,9 +77,9 @@ achievement_tbl = {
 		title = "North Prontera Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north prontera field"
+			details = "Discover treasure in north Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in north prontera field" } },
+		resource = { [1] = { text = "Discover treasure in north Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -91,9 +91,9 @@ achievement_tbl = {
 		title = "West Prontera Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in west prontera field"
+			details = "Discover treasure in west Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in west prontera field" } },
+		resource = { [1] = { text = "Discover treasure in west Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -105,9 +105,9 @@ achievement_tbl = {
 		title = "West Prontera Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in west prontera field"
+			details = "Discover treasure in west Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in west prontera field" } },
+		resource = { [1] = { text = "Discover treasure in west Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -119,9 +119,9 @@ achievement_tbl = {
 		title = "East Prontera Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east prontera field"
+			details = "Discover treasure in east Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in east prontera field" } },
+		resource = { [1] = { text = "Discover treasure in east Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -133,9 +133,9 @@ achievement_tbl = {
 		title = "South Prontera Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south prontera field"
+			details = "Discover treasure in south Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in south prontera field" } },
+		resource = { [1] = { text = "Discover treasure in south Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -147,9 +147,9 @@ achievement_tbl = {
 		title = "South Prontera Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south prontera field"
+			details = "Discover treasure in south Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in south prontera field" } },
+		resource = { [1] = { text = "Discover treasure in south Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -161,9 +161,9 @@ achievement_tbl = {
 		title = "South Prontera Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south prontera field"
+			details = "Discover treasure in south Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in south prontera field" } },
+		resource = { [1] = { text = "Discover treasure in south Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -175,9 +175,9 @@ achievement_tbl = {
 		title = "South Prontera Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south prontera field"
+			details = "Discover treasure in south Prontera field"
 		},
-		resource = { [1] = { text = "Discover treasure in south prontera field" } },
+		resource = { [1] = { text = "Discover treasure in south Prontera field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -189,9 +189,9 @@ achievement_tbl = {
 		title = "East Geffen Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east geffen field"
+			details = "Discover treasure in east Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in east geffen field" } },
+		resource = { [1] = { text = "Discover treasure in east Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -203,9 +203,9 @@ achievement_tbl = {
 		title = "Southeast Geffen Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in southeast geffen field"
+			details = "Discover treasure in southeast Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in southeast geffen field" } },
+		resource = { [1] = { text = "Discover treasure in southeast Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -217,9 +217,9 @@ achievement_tbl = {
 		title = "Northwest Geffen Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in northwest geffen field"
+			details = "Discover treasure in northwest Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in northwest geffen field" } },
+		resource = { [1] = { text = "Discover treasure in northwest Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -231,9 +231,9 @@ achievement_tbl = {
 		title = "Northwest Geffen Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in northwest geffen field"
+			details = "Discover treasure in northwest Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in northwest geffen field" } },
+		resource = { [1] = { text = "Discover treasure in northwest Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -245,9 +245,9 @@ achievement_tbl = {
 		title = "Northwest Geffen Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in northwest geffen field"
+			details = "Discover treasure in northwest Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in northwest geffen field" } },
+		resource = { [1] = { text = "Discover treasure in northwest Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -259,9 +259,9 @@ achievement_tbl = {
 		title = "South Geffen Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south geffen field"
+			details = "Discover treasure in south Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in south geffen field" } },
+		resource = { [1] = { text = "Discover treasure in south Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -273,9 +273,9 @@ achievement_tbl = {
 		title = "South Geffen Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south geffen field"
+			details = "Discover treasure in south Geffen field"
 		},
-		resource = { [1] = { text = "Discover treasure in south geffen field" } },
+		resource = { [1] = { text = "Discover treasure in south Geffen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -287,9 +287,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -301,9 +301,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -315,9 +315,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -329,9 +329,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -343,9 +343,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(5)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -357,9 +357,9 @@ achievement_tbl = {
 		title = "Sograt Desert Field Exploration(6)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sograt desert field"
+			details = "Discover treasure in Sograt Desert field"
 		},
-		resource = { [1] = { text = "Discover treasure in sograt desert field" } },
+		resource = { [1] = { text = "Discover treasure in Sograt Desert field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -371,9 +371,9 @@ achievement_tbl = {
 		title = "Southwest Payon Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in southwest payon field"
+			details = "Discover treasure in southwest Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in southwest payon field" } },
+		resource = { [1] = { text = "Discover treasure in southwest Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -385,9 +385,9 @@ achievement_tbl = {
 		title = "Southwest Payon Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in southwest payon field"
+			details = "Discover treasure in southwest Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in southwest payon field" } },
+		resource = { [1] = { text = "Discover treasure in southwest Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -399,9 +399,9 @@ achievement_tbl = {
 		title = "Southwest Payon Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in southwest payon field"
+			details = "Discover treasure in southwest Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in southwest payon field" } },
+		resource = { [1] = { text = "Discover treasure in southwest Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -413,9 +413,9 @@ achievement_tbl = {
 		title = "Southwest Payon Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in southwest payon field"
+			details = "Discover treasure in southwest Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in southwest payon field" } },
+		resource = { [1] = { text = "Discover treasure in southwest Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -427,9 +427,9 @@ achievement_tbl = {
 		title = "East Payon Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east payon field"
+			details = "Discover treasure in east Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in east payon field" } },
+		resource = { [1] = { text = "Discover treasure in east Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -441,9 +441,9 @@ achievement_tbl = {
 		title = "East Payon Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east payon field"
+			details = "Discover treasure in east Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in east payon field" } },
+		resource = { [1] = { text = "Discover treasure in east Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -455,9 +455,9 @@ achievement_tbl = {
 		title = "East Payon Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east payon field"
+			details = "Discover treasure in east Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in east payon field" } },
+		resource = { [1] = { text = "Discover treasure in east Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -469,9 +469,9 @@ achievement_tbl = {
 		title = "East Payon Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in east payon field"
+			details = "Discover treasure in east Payon field"
 		},
-		resource = { [1] = { text = "Discover treasure in east payon field" } },
+		resource = { [1] = { text = "Discover treasure in east Payon field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -483,9 +483,9 @@ achievement_tbl = {
 		title = "North Mjolnir Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north mjolnir field"
+			details = "Discover treasure in north Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in north mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in north Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -497,9 +497,9 @@ achievement_tbl = {
 		title = "North Mjolnir Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north mjolnir field"
+			details = "Discover treasure in north Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in north mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in north Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -511,9 +511,9 @@ achievement_tbl = {
 		title = "North Mjolnir Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north mjolnir field"
+			details = "Discover treasure in north Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in north mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in north Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -525,9 +525,9 @@ achievement_tbl = {
 		title = "North Mjolnir Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north mjolnir field"
+			details = "Discover treasure in north Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in north mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in north Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -539,9 +539,9 @@ achievement_tbl = {
 		title = "North Mjolnir Field Exploration(5)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north mjolnir field"
+			details = "Discover treasure in north Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in north mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in north Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -553,9 +553,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -567,9 +567,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -581,9 +581,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -595,9 +595,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -609,9 +609,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(5)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -623,9 +623,9 @@ achievement_tbl = {
 		title = "South Mjolnir Field Exploration(6)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south mjolnir field"
+			details = "Discover treasure in south Mjolnir field"
 		},
-		resource = { [1] = { text = "Discover treasure in south mjolnir field" } },
+		resource = { [1] = { text = "Discover treasure in south Mjolnir field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -637,9 +637,9 @@ achievement_tbl = {
 		title = "South Aldebaran Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south aldebaran field"
+			details = "Discover treasure in south Aldebaran field"
 		},
-		resource = { [1] = { text = "Discover treasure in south aldebaran field" } },
+		resource = { [1] = { text = "Discover treasure in south Aldebaran field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -651,9 +651,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -665,9 +665,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -679,9 +679,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -693,9 +693,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -707,9 +707,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(5)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -721,9 +721,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(6)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -735,9 +735,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(7)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -749,9 +749,9 @@ achievement_tbl = {
 		title = "Comodo Field Exploration(8)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo field"
+			details = "Discover treasure in Comodo field"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo field" } },
+		resource = { [1] = { text = "Discover treasure in Comodo field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -763,9 +763,9 @@ achievement_tbl = {
 		title = "Border Checkpoint Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in border checkpoint field"
+			details = "Discover treasure in Border Checkpoint field"
 		},
-		resource = { [1] = { text = "Discover treasure in border checkpoint field" } },
+		resource = { [1] = { text = "Discover treasure in Border Checkpoint field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -777,9 +777,9 @@ achievement_tbl = {
 		title = "Border Checkpoint Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in border checkpoint field"
+			details = "Discover treasure in Border Checkpoint field"
 		},
-		resource = { [1] = { text = "Discover treasure in border checkpoint field" } },
+		resource = { [1] = { text = "Discover treasure in Border Checkpoint field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -791,9 +791,9 @@ achievement_tbl = {
 		title = "Kiel Hyre Mansion Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in kiel hyre mansion field"
+			details = "Discover treasure in Kiel Hyre Mansion field"
 		},
-		resource = { [1] = { text = "Discover treasure in kiel hyre mansion field" } },
+		resource = { [1] = { text = "Discover treasure in Kiel Hyre Mansion field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -805,9 +805,9 @@ achievement_tbl = {
 		title = "El Mes Plateau Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in el mes plateau field"
+			details = "Discover treasure in El Mes Plateau field"
 		},
-		resource = { [1] = { text = "Discover treasure in el mes plateau field" } },
+		resource = { [1] = { text = "Discover treasure in El Mes Plateau field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -819,9 +819,9 @@ achievement_tbl = {
 		title = "El Mes Plateau Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in el mes plateau field"
+			details = "Discover treasure in El Mes Plateau field"
 		},
-		resource = { [1] = { text = "Discover treasure in el mes plateau field" } },
+		resource = { [1] = { text = "Discover treasure in El Mes Plateau field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -833,9 +833,9 @@ achievement_tbl = {
 		title = "El Mes Plateau Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in el mes plateau field"
+			details = "Discover treasure in El Mes Plateau field"
 		},
-		resource = { [1] = { text = "Discover treasure in el mes plateau field" } },
+		resource = { [1] = { text = "Discover treasure in El Mes Plateau field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -847,9 +847,9 @@ achievement_tbl = {
 		title = "El Mes Gorge Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in el mes gorge field"
+			details = "Discover treasure in El Mes Gorge field"
 		},
-		resource = { [1] = { text = "Discover treasure in el mes gorge field" } },
+		resource = { [1] = { text = "Discover treasure in El Mes Gorge field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -861,9 +861,9 @@ achievement_tbl = {
 		title = "Kiel Hyre Academy Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in kiel hyre academy field"
+			details = "Discover treasure in Kiel Hyre Academy field"
 		},
-		resource = { [1] = { text = "Discover treasure in kiel hyre academy field" } },
+		resource = { [1] = { text = "Discover treasure in Kiel Hyre Academy field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -875,9 +875,9 @@ achievement_tbl = {
 		title = "Guard Camp Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in guard camp field"
+			details = "Discover treasure in Guard Camp field"
 		},
-		resource = { [1] = { text = "Discover treasure in guard camp field" } },
+		resource = { [1] = { text = "Discover treasure in Guard Camp field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -889,9 +889,9 @@ achievement_tbl = {
 		title = "Yuno Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in yuno field"
+			details = "Discover treasure in Yuno field"
 		},
-		resource = { [1] = { text = "Discover treasure in yuno field" } },
+		resource = { [1] = { text = "Discover treasure in Yuno field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -903,9 +903,9 @@ achievement_tbl = {
 		title = "Front of Thanatos Tower Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in front of thanatos tower field"
+			details = "Discover treasure in front of Thanatos Tower field"
 		},
-		resource = { [1] = { text = "Discover treasure in front of thanatos tower field" } },
+		resource = { [1] = { text = "Discover treasure in front of Thanatos Tower field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -917,9 +917,9 @@ achievement_tbl = {
 		title = "Hugel Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in hugel field"
+			details = "Discover treasure in Hugel field"
 		},
-		resource = { [1] = { text = "Discover treasure in hugel field" } },
+		resource = { [1] = { text = "Discover treasure in Hugel field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -931,9 +931,9 @@ achievement_tbl = {
 		title = "Hugel Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in hugel field"
+			details = "Discover treasure in Hugel field"
 		},
-		resource = { [1] = { text = "Discover treasure in hugel field" } },
+		resource = { [1] = { text = "Discover treasure in Hugel field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -945,9 +945,9 @@ achievement_tbl = {
 		title = "Hugel Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in hugel field"
+			details = "Discover treasure in Hugel field"
 		},
-		resource = { [1] = { text = "Discover treasure in hugel field" } },
+		resource = { [1] = { text = "Discover treasure in Hugel field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -959,9 +959,9 @@ achievement_tbl = {
 		title = "Abyss Lake Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in abyss lake field"
+			details = "Discover treasure in Abyss Lake field"
 		},
-		resource = { [1] = { text = "Discover treasure in abyss lake field" } },
+		resource = { [1] = { text = "Discover treasure in Abyss Lake field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1085,9 +1085,9 @@ achievement_tbl = {
 		title = "Lighthalzen Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in lighthalzen field"
+			details = "Discover treasure in Lighthalzen field"
 		},
-		resource = { [1] = { text = "Discover treasure in lighthalzen field" } },
+		resource = { [1] = { text = "Discover treasure in Lighthalzen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1099,9 +1099,9 @@ achievement_tbl = {
 		title = "Lighthalzen Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in lighthalzen field"
+			details = "Discover treasure in Lighthalzen field"
 		},
-		resource = { [1] = { text = "Discover treasure in lighthalzen field" } },
+		resource = { [1] = { text = "Discover treasure in Lighthalzen field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1127,9 +1127,9 @@ achievement_tbl = {
 		title = "Rachel Audhumbla Plains Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel audhumbla plains field"
+			details = "Discover treasure in Rachel Audhumbla Plains field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel audhumbla plains field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Audhumbla Plains field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1141,9 +1141,9 @@ achievement_tbl = {
 		title = "Rachel Plains Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel plains field"
+			details = "Discover treasure in Rachel Plains field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel plains field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Plains field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1155,9 +1155,9 @@ achievement_tbl = {
 		title = "Rachel Plains Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel plains field"
+			details = "Discover treasure in Rachel Plains field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel plains field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Plains field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1169,9 +1169,9 @@ achievement_tbl = {
 		title = "Rachel Plains Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel plains field"
+			details = "Discover treasure in Rachel Plains field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel plains field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Plains field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1183,9 +1183,9 @@ achievement_tbl = {
 		title = "Rachel Audhumbla Grassland Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel audhumbla grassland field"
+			details = "Discover treasure in Rachel Audhumbla Grassland field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel audhumbla grassland field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Audhumbla Grassland field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1197,9 +1197,9 @@ achievement_tbl = {
 		title = "Rachel Audhumbla Grassland Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel audhumbla grassland field"
+			details = "Discover treasure in Rachel Audhumbla Grassland field"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel audhumbla grassland field" } },
+		resource = { [1] = { text = "Discover treasure in Rachel Audhumbla Grassland field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1211,9 +1211,9 @@ achievement_tbl = {
 		title = "Portus Luna Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in portus luna field"
+			details = "Discover treasure in Portus Luna field"
 		},
-		resource = { [1] = { text = "Discover treasure in portus luna field" } },
+		resource = { [1] = { text = "Discover treasure in Portus Luna field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1225,9 +1225,9 @@ achievement_tbl = {
 		title = "Veins Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in veins field"
+			details = "Discover treasure in Veins field"
 		},
-		resource = { [1] = { text = "Discover treasure in veins field" } },
+		resource = { [1] = { text = "Discover treasure in Veins field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1239,9 +1239,9 @@ achievement_tbl = {
 		title = "Veins Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in veins field"
+			details = "Discover treasure in Veins field"
 		},
-		resource = { [1] = { text = "Discover treasure in veins field" } },
+		resource = { [1] = { text = "Discover treasure in Veins field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1253,9 +1253,9 @@ achievement_tbl = {
 		title = "Veins Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in veins field"
+			details = "Discover treasure in Veins field"
 		},
-		resource = { [1] = { text = "Discover treasure in veins field" } },
+		resource = { [1] = { text = "Discover treasure in Veins field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1267,9 +1267,9 @@ achievement_tbl = {
 		title = "Veins Field Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in veins field"
+			details = "Discover treasure in Veins field"
 		},
-		resource = { [1] = { text = "Discover treasure in veins field" } },
+		resource = { [1] = { text = "Discover treasure in Veins field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1281,9 +1281,9 @@ achievement_tbl = {
 		title = "Veins Field Exploration(5)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in veins field"
+			details = "Discover treasure in Veins field"
 		},
-		resource = { [1] = { text = "Discover treasure in veins field" } },
+		resource = { [1] = { text = "Discover treasure in Veins field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1295,9 +1295,9 @@ achievement_tbl = {
 		title = "Eclage Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in eclage field"
+			details = "Discover treasure in Eclage field"
 		},
-		resource = { [1] = { text = "Discover treasure in eclage field" } },
+		resource = { [1] = { text = "Discover treasure in Eclage field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1309,9 +1309,9 @@ achievement_tbl = {
 		title = "North Bitfrost Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in north bitfrost field"
+			details = "Discover treasure in North Bifrost field"
 		},
-		resource = { [1] = { text = "Discover treasure in north bitfrost field" } },
+		resource = { [1] = { text = "Discover treasure in North Bifrost field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1323,9 +1323,9 @@ achievement_tbl = {
 		title = "South Bitfrost Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in south bitfrost field"
+			details = "Discover treasure in South Bifrost field"
 		},
-		resource = { [1] = { text = "Discover treasure in south bitfrost field" } },
+		resource = { [1] = { text = "Discover treasure in South Bifrost field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1337,9 +1337,9 @@ achievement_tbl = {
 		title = "Splendide Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in splendide field"
+			details = "Discover treasure in Splendide field"
 		},
-		resource = { [1] = { text = "Discover treasure in splendide field" } },
+		resource = { [1] = { text = "Discover treasure in Splendide field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1351,9 +1351,9 @@ achievement_tbl = {
 		title = "Splendide Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in splendide field"
+			details = "Discover treasure in Splendide field"
 		},
-		resource = { [1] = { text = "Discover treasure in splendide field" } },
+		resource = { [1] = { text = "Discover treasure in Splendide field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1365,9 +1365,9 @@ achievement_tbl = {
 		title = "Splendide Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in splendide field"
+			details = "Discover treasure in Splendide field"
 		},
-		resource = { [1] = { text = "Discover treasure in splendide field" } },
+		resource = { [1] = { text = "Discover treasure in Splendide field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1379,9 +1379,9 @@ achievement_tbl = {
 		title = "Manuk Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in manuk field"
+			details = "Discover treasure in Manuk field"
 		},
-		resource = { [1] = { text = "Discover treasure in manuk field" } },
+		resource = { [1] = { text = "Discover treasure in Manuk field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1393,9 +1393,9 @@ achievement_tbl = {
 		title = "Manuk Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in manuk field"
+			details = "Discover treasure in Manuk field"
 		},
-		resource = { [1] = { text = "Discover treasure in manuk field" } },
+		resource = { [1] = { text = "Discover treasure in Manuk field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1407,9 +1407,9 @@ achievement_tbl = {
 		title = "Manuk Field Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in manuk field"
+			details = "Discover treasure in Manuk field"
 		},
-		resource = { [1] = { text = "Discover treasure in manuk field" } },
+		resource = { [1] = { text = "Discover treasure in Manuk field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1421,9 +1421,9 @@ achievement_tbl = {
 		title = "Outskirts of Kamidal Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in outskirts of kamidal field"
+			details = "Discover treasure in Outskirts of Kamidal field"
 		},
-		resource = { [1] = { text = "Discover treasure in outskirts of kamidal field" } },
+		resource = { [1] = { text = "Discover treasure in Outskirts of Kamidal field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1435,9 +1435,9 @@ achievement_tbl = {
 		title = "Outskirts of Kamidal Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in outskirts of kamidal field"
+			details = "Discover treasure in Outskirts of Kamidal field"
 		},
-		resource = { [1] = { text = "Discover treasure in outskirts of kamidal field" } },
+		resource = { [1] = { text = "Discover treasure in Outskirts of Kamidal field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1449,9 +1449,9 @@ achievement_tbl = {
 		title = "Amatsu Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in amatsu field"
+			details = "Discover treasure in Amatsu field"
 		},
-		resource = { [1] = { text = "Discover treasure in amatsu field" } },
+		resource = { [1] = { text = "Discover treasure in Amatsu field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1463,9 +1463,9 @@ achievement_tbl = {
 		title = "Kunlun Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in kunlun field"
+			details = "Discover treasure in Kunlun field"
 		},
-		resource = { [1] = { text = "Discover treasure in kunlun field" } },
+		resource = { [1] = { text = "Discover treasure in Kunlun field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1477,9 +1477,9 @@ achievement_tbl = {
 		title = "Gonryun Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in gonryun field"
+			details = "Discover treasure in Gonryun field"
 		},
-		resource = { [1] = { text = "Discover treasure in gonryun field" } },
+		resource = { [1] = { text = "Discover treasure in Gonryun field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1491,9 +1491,9 @@ achievement_tbl = {
 		title = "Ayothaya Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in ayothaya field"
+			details = "Discover treasure in Ayothaya field"
 		},
-		resource = { [1] = { text = "Discover treasure in ayothaya field" } },
+		resource = { [1] = { text = "Discover treasure in Ayothaya field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1505,9 +1505,9 @@ achievement_tbl = {
 		title = "Moscovia Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in moscovia field"
+			details = "Discover treasure in Moscovia field"
 		},
-		resource = { [1] = { text = "Discover treasure in moscovia field" } },
+		resource = { [1] = { text = "Discover treasure in Moscovia field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1519,9 +1519,9 @@ achievement_tbl = {
 		title = "Brasilis Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in brasilis field"
+			details = "Discover treasure in Brasilis field"
 		},
-		resource = { [1] = { text = "Discover treasure in brasilis field" } },
+		resource = { [1] = { text = "Discover treasure in Brasilis field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1533,9 +1533,9 @@ achievement_tbl = {
 		title = "Dewata Field Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in dewata field"
+			details = "Discover treasure in Dewata field"
 		},
-		resource = { [1] = { text = "Discover treasure in dewata field" } },
+		resource = { [1] = { text = "Discover treasure in Dewata field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1547,9 +1547,9 @@ achievement_tbl = {
 		title = "Malaya Field Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in malaya field"
+			details = "Discover treasure in Malaya field"
 		},
-		resource = { [1] = { text = "Discover treasure in malaya field" } },
+		resource = { [1] = { text = "Discover treasure in Malaya field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1561,9 +1561,9 @@ achievement_tbl = {
 		title = "Malaya Field Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in malaya field"
+			details = "Discover treasure in Malaya field"
 		},
-		resource = { [1] = { text = "Discover treasure in malaya field" } },
+		resource = { [1] = { text = "Discover treasure in Malaya field" } },
 		reward = { item = 22876 },
 		score = 10
 	},
@@ -1575,9 +1575,9 @@ achievement_tbl = {
 		title = "Abbey Underground Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in abbey underground dungeon"
+			details = "Discover treasure in Abbey Underground dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in abbey underground dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Abbey Underground dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1589,9 +1589,9 @@ achievement_tbl = {
 		title = "Abyss Lake Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in abyss lake dungeon"
+			details = "Discover treasure in Abyss Lake dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in abyss lake dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Abyss Lake dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1603,9 +1603,9 @@ achievement_tbl = {
 		title = "Clock Tower Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in clock tower dungeon"
+			details = "Discover treasure in Clock Tower dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in clock tower dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Clock Tower dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1617,9 +1617,9 @@ achievement_tbl = {
 		title = "Amatsu Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in amatsu dungeon"
+			details = "Discover treasure in Amatsu dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in amatsu dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Amatsu dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1631,9 +1631,9 @@ achievement_tbl = {
 		title = "Ant Hell Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in ant hell dungeon"
+			details = "Discover treasure in Ant Hell dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in ant hell dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Ant Hell dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1645,9 +1645,9 @@ achievement_tbl = {
 		title = "Ayothaya Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in ayothaya dungeon"
+			details = "Discover treasure in Ayothaya dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in ayothaya dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Ayothaya dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1659,9 +1659,9 @@ achievement_tbl = {
 		title = "Comodo Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in comodo dungeon"
+			details = "Discover treasure in Comodo dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in comodo dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Comodo dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1673,9 +1673,9 @@ achievement_tbl = {
 		title = "Brasilis Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in brasilis dungeon"
+			details = "Discover treasure in Brasilis dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in brasilis dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Brasilis dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1687,9 +1687,9 @@ achievement_tbl = {
 		title = "Clock Tower Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in clock tower dungeon"
+			details = "Discover treasure in Clock Tower dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in clock tower dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Clock Tower dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1701,9 +1701,9 @@ achievement_tbl = {
 		title = "Istana Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in istana dungeon"
+			details = "Discover treasure in Istana dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in istana dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Istana dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1715,9 +1715,9 @@ achievement_tbl = {
 		title = "Scaraba Hole Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in scaraba hole dungeon"
+			details = "Discover treasure in Scaraba Hole dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in scaraba hole dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Scaraba Hole dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1729,9 +1729,9 @@ achievement_tbl = {
 		title = "Bitfrost Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in bitfrost dungeon"
+			details = "Discover treasure in Bifrost dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in bitfrost dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Bifrost dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1743,9 +1743,9 @@ achievement_tbl = {
 		title = "Einbroch Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in einbroch dungeon"
+			details = "Discover treasure in Einbroch dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in einbroch dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Einbroch dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1757,9 +1757,9 @@ achievement_tbl = {
 		title = "Geffen Underground Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in geffen underground dungeon"
+			details = "Discover treasure in Geffen Underground dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in geffen underground dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Geffen Underground dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1771,9 +1771,9 @@ achievement_tbl = {
 		title = "Glastheim Dungeon Exploration(1)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in glastheim dungeon"
+			details = "Discover treasure in Glastheim dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in glastheim dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Glastheim dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1785,9 +1785,9 @@ achievement_tbl = {
 		title = "Glastheim Dungeon Exploration(2)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in glastheim dungeon"
+			details = "Discover treasure in Glastheim dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in glastheim dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Glastheim dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1799,9 +1799,9 @@ achievement_tbl = {
 		title = "Glastheim Dungeon Exploration(3)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in glastheim dungeon"
+			details = "Discover treasure in Glastheim dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in glastheim dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Glastheim dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1813,9 +1813,9 @@ achievement_tbl = {
 		title = "Glastheim Dungeon Exploration(4)",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in glastheim dungeon"
+			details = "Discover treasure in Glastheim dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in glastheim dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Glastheim dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1841,9 +1841,9 @@ achievement_tbl = {
 		title = "Rachel Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in rachel dungeon"
+			details = "Discover treasure in Rachel dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in rachel dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Rachel dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1855,9 +1855,9 @@ achievement_tbl = {
 		title = "Sphinx Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sphinx dungeon"
+			details = "Discover treasure in Sphinx dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in sphinx dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Sphinx dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1869,9 +1869,9 @@ achievement_tbl = {
 		title = "Izlude Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in izlude dungeon"
+			details = "Discover treasure in Izlude dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in izlude dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Izlude dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1883,9 +1883,9 @@ achievement_tbl = {
 		title = "Robot Factory Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in robot factory dungeon"
+			details = "Discover treasure in Robot Factory dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in robot factory dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Robot Factory dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1897,9 +1897,9 @@ achievement_tbl = {
 		title = "Bio Lab Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in bio lab dungeon"
+			details = "Discover treasure in Bio Lab dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in bio lab dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Bio Lab dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1911,9 +1911,9 @@ achievement_tbl = {
 		title = "Gonryun Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in gonryun dungeon"
+			details = "Discover treasure in Gonryun dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in gonryun dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Gonryun dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1925,9 +1925,9 @@ achievement_tbl = {
 		title = "Nogg Road Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in nogg road dungeon"
+			details = "Discover treasure in Nogg Road dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in nogg road dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Nogg Road dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1939,9 +1939,9 @@ achievement_tbl = {
 		title = "Coal Mine Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in Coal mine dungeon"
+			details = "Discover treasure in Coal Mine dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in Coal mine dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Coal Mine dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1953,9 +1953,9 @@ achievement_tbl = {
 		title = "Pyramid Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in pyramid dungeon"
+			details = "Discover treasure in Pyramid dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in pyramid dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Pyramid dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1967,9 +1967,9 @@ achievement_tbl = {
 		title = "Orc Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in orc dungeon"
+			details = "Discover treasure in Orc dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in orc dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Orc dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1981,9 +1981,9 @@ achievement_tbl = {
 		title = "Payon Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in payon dungeon"
+			details = "Discover treasure in Payon dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in payon dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Payon dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -1995,9 +1995,9 @@ achievement_tbl = {
 		title = "Labyrinth Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in labyrinth dungeon"
+			details = "Discover treasure in Labyrinth dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in labyrinth dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Labyrinth dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2009,9 +2009,9 @@ achievement_tbl = {
 		title = "Undersea Tunnel Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in undersea tunnel dungeon"
+			details = "Discover treasure in Undersea Tunnel dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in undersea tunnel dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Undersea Tunnel dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2023,9 +2023,9 @@ achievement_tbl = {
 		title = "Thanatos Tower Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in thanatos tower dungeon"
+			details = "Discover treasure in Thanatos Tower dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in thanatos tower dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Thanatos Tower dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2037,9 +2037,9 @@ achievement_tbl = {
 		title = "Thor Volcano Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in thor volcano dungeon"
+			details = "Discover treasure in Thor Volcano dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in thor volcano dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Thor Volcano dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2051,9 +2051,9 @@ achievement_tbl = {
 		title = "Sunken Ship Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in sunken ship dungeon"
+			details = "Discover treasure in Sunken Ship dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in sunken ship dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Sunken Ship dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2065,9 +2065,9 @@ achievement_tbl = {
 		title = "Turtle Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in turtle dungeon"
+			details = "Discover treasure in Turtle dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in turtle dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Turtle dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},
@@ -2079,9 +2079,9 @@ achievement_tbl = {
 		title = "Toy Factory Dungeon Exploration",
 		content = {
 			summary = "Discover hidden treasure",
-			details = "Discover treasure in toy factory dungeon"
+			details = "Discover treasure in Toy Factory dungeon"
 		},
-		resource = { [1] = { text = "Discover treasure in toy factory dungeon" } },
+		resource = { [1] = { text = "Discover treasure in Toy Factory dungeon" } },
 		reward = { item = 22876 },
 		score = 20
 	},


### PR DESCRIPTION
In English, location names must be capitalized.
You don't write "in the paris suburbs" but "in the Paris suburbs".