### PR TITLE
Fix a typo and likely a translation error

### DIFF
--- a/Translation/Renewal/data/cardprefixnametable.txt
+++ b/Translation/Renewal/data/cardprefixnametable.txt
@@ -78,7 +78,7 @@
 4076#Cursing#
 4077#Under a Cast#
 4078#of Recovery#
-4079#of Mustle#
+4079#of Muscle#
 4080#Fisher#
 4081#Glorious#
 4082#Gigantic#
@@ -95,7 +95,7 @@
 4093#Cure#
 4094#Kingbird#
 4095#Genie's#
-4096#Venomer's#
+4096#Venomous#
 4097#Green#
 4098#of Zephyrus#
 4099#of Ifrit#


### PR DESCRIPTION
'Mustle' is not an english word.
Neither is 'Venomer'.

4079 is a Mantis card which gives +3 STR so... yeah, easy, it should be Muscle.

4096 is a Zenorc Card which poisons.
I don't know Korean, but DeepL and Google Translate say that '베노머스' is 'Venomous'.

There's another occurence of the word 'Venomous' as a card prefix but it's for a headgear card (mob: Venedi) so we're good ^_^