### PR TITLE
Correct EN spelling for singular is 'Gypsy' not 'Gypsi'

### DIFF
--- a/Translation/Renewal/System/achievement_list_EN.lub
+++ b/Translation/Renewal/System/achievement_list_EN.lub
@@ -3641,7 +3641,7 @@ achievement_tbl = {
 		title = "Warrior (2)",
 		content = {
 			summary = "Job change to transcendent 2-2 classes",
-			details = "Paladin, Creator, Stalker, Proffesor, Champion, Clown or Gypsi."
+			details = "Paladin, Creator, Stalker, Proffesor, Champion, Clown or Gypsy."
 		},
 		resource = { [1] = { text = "Job change to transcendent 2-2 classes" } },
 		reward = { buff = 12 },


### PR DESCRIPTION
One gypsy, two gypsies.